### PR TITLE
feat: Add the function of parsing the merge request URL and obtaining…

### DIFF
--- a/src/gitlab/schemas.ts
+++ b/src/gitlab/schemas.ts
@@ -304,6 +304,35 @@ export const CreateBranchSchema = ProjectParamsSchema.extend({
     .describe("Source branch/commit for new branch")
 });
 
+export const GetProjectIdFromMrUrlInputSchema = z.object({
+  mr_url: z.string().url().describe("The full URL of the GitLab Merge Request (e.g., https://gitlab.example.com/namespace/project/-/merge_requests/123)")
+});
+
+export const GetProjectIdFromMrUrlOutputSchema = z.object({
+  project_id: z.number().describe("The numeric ID of the GitLab project")
+});
+
+// Schema for the position object in the diff thread
+export const GitLabDiffPositionSchema = z.object({
+  base_sha: z.string().describe("Base commit SHA of the diff"),
+  start_sha: z.string().describe("Start commit SHA of the diff"),
+  head_sha: z.string().describe("Head commit SHA of the diff"),
+  old_path: z.string().describe("File path in the old version"),
+  new_path: z.string().describe("File path in the new version"),
+  position_type: z.string().default('text').describe("Type of the position, usually 'text'"),
+  old_line: z.number().optional().describe("Line number in the old file (if applicable)"),
+  new_line: z.number().describe("Line number in the new file"),
+});
+
+// Schema for the create_merge_request_diff_thread tool input
+export const CreateMergeRequestDiffThreadSchema = ProjectParamsSchema.extend({
+  merge_request_iid: z.number().describe("The IID of the merge request"),
+  body: z.string().describe("The content of the comment thread"),
+  position: GitLabDiffPositionSchema.describe("Position object for the diff comment"),
+  commit_id: z.string().optional().describe("Commit ID if the comment is for a specific commit diff")
+});
+
+
 // Export types
 export type GitLabAuthor = z.infer<typeof GitLabAuthorSchema>;
 export type GitLabFork = z.infer<typeof GitLabForkSchema>;
@@ -323,3 +352,6 @@ export type CreateMergeRequestOptions = z.infer<typeof CreateMergeRequestOptions
 export type CreateBranchOptions = z.infer<typeof CreateBranchOptionsSchema>;
 export type GitLabCreateUpdateFileResponse = z.infer<typeof GitLabCreateUpdateFileResponseSchema>;
 export type GitLabSearchResponse = z.infer<typeof GitLabSearchResponseSchema>;
+export type GetProjectIdFromMrUrlInput = z.infer<typeof GetProjectIdFromMrUrlInputSchema>;
+export type GetProjectIdFromMrUrlOutput = z.infer<typeof GetProjectIdFromMrUrlOutputSchema>;
+export type CreateMergeRequestDiffThreadInput = z.infer<typeof CreateMergeRequestDiffThreadSchema>;


### PR DESCRIPTION
… the project ID, and add the function of creating a merge request difference thread and related modes

<!-- Provide a brief description of your changes -->

## Description

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: <!-- e.g., filesystem, github -->
- Changes to: <!-- e.g., tools, resources, prompts -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this with an LLM client? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [ ] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

添加新的 GitLab 特定函数以解析合并请求 URL 并创建差异线程

新功能：
- 实现从 GitLab 合并请求 URL 中提取项目 ID 的函数
- 增加在 GitLab 合并请求上创建具有精确定位行和文件的差异线程的功能

增强功能：
- 使用两个新方法扩展 GitLab 服务器工具：`get_project_id_from_mr_url` 和 `create_merge_request_diff_thread`
- 改进合并请求操作的 URL 解析和错误处理

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add new GitLab-specific functions to parse merge request URLs and create diff threads

New Features:
- Implement a function to extract project ID from a GitLab merge request URL
- Add capability to create diff threads on GitLab merge requests with precise line and file positioning

Enhancements:
- Extend the GitLab server tools with two new methods: get_project_id_from_mr_url and create_merge_request_diff_thread
- Improve URL parsing and error handling for merge request operations

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added the ability to extract a project ID from a GitLab Merge Request URL.
	- Enabled creation of new diff discussion threads on GitLab Merge Requests via the server API.

- **API Enhancements**
	- Introduced new input forms and validation for merge request URLs and diff thread creation.
	- Expanded server capabilities to support the new tools for project ID extraction and diff thread discussions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->